### PR TITLE
Fix typo in arm64

### DIFF
--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://github.com/prometheus/node_exporter/releases/download/v1.5.0/node_exporter-1.5.0.linux-arm64.tar.gz.tar.gz
+SOURCE_URL=https://github.com/prometheus/node_exporter/releases/download/v1.5.0/node_exporter-1.5.0.linux-arm64.tar.gz
 SOURCE_SUM=e031a539af9a619c06774788b54c23fccc2a852d41437315725a086ccdb0ed16
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz


### PR DESCRIPTION
## Problem
The arm64 config file was broken

- *Description of why you made this PR*
It was a typo which was `.tar.gz.tar.gz` while it should've been `.tar.gz`

## Solution
Fixed the typo